### PR TITLE
change access level of MidiTime properties to public

### DIFF
--- a/Source/MidiEvent/Meta/MidiTime.swift
+++ b/Source/MidiEvent/Meta/MidiTime.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct MidiTime {
-    let inSeconds: TimeInterval
-    let inTicks: Ticks
+    public let inSeconds: TimeInterval
+    public let inTicks: Ticks
 }
 
 public extension MidiTime {


### PR DESCRIPTION
@matsuneさん, this is a great project! Very well done! 🙌 Thank you, and the other contributors, for creating it.

I was having an issue with accessing the `MidiTime.inTicks` property that I wanted to use, so I wanted to make those public.  Because there was no explicit access level set on the properties in `MidiTime`, it was getting the default `internal`. I didn't see much a danger in exposing them and thought maybe others might want access to those properties too, so I'm submitting a pull request for your review.

Thanks again!