### PR TITLE
Make parameters of MidiTime public

### DIFF
--- a/Source/MidiEvent/Meta/MidiTime.swift
+++ b/Source/MidiEvent/Meta/MidiTime.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct MidiTime {
-    let inSeconds: TimeInterval
-    let inTicks: Ticks
+    public let inSeconds: TimeInterval
+    public let inTicks: Ticks
 }
 
 public extension MidiTime {


### PR DESCRIPTION
Changed access modifiers of inSeconds and inTick in MidiTime, so that we can read them. 